### PR TITLE
Corrected the width of the circular convolution adjustment

### DIFF
--- a/ntm/memory.py
+++ b/ntm/memory.py
@@ -9,9 +9,9 @@ import numpy as np
 def _convolve(w, s):
     """Circular convolution implementation."""
     assert s.size(0) == 3
-    t = torch.cat([w[-2:], w, w[:2]])
+    t = torch.cat([w[-1:], w, w[:1]])
     c = F.conv1d(t.view(1, 1, -1), s.view(1, 1, -1)).view(-1)
-    return c[1:-1]
+    return c
 
 
 class NTMMemory(nn.Module):


### PR DESCRIPTION
The code concats 2 elements to each side but only needs to concat 1 to each side.

Tested with the following code

```python
import torch
import torch.nn
from torch.nn import functional as F
from torch.autograd import Variable
from random import randint

def _convolve_original(w, s):
    """Circular convolution implementation."""
    assert s.size(0) == 3
    t = torch.cat([w[-2:], w, w[:2]])
    c = F.conv1d(t.view(1, 1, -1), s.view(1, 1, -1)).view(-1)
    return c[1:-1]


def _convolve_new(w, s):
    """Circular convolution implementation."""
    assert s.size(0) == 3
    t = torch.cat([w[-1:], w, w[:1]])
    c = F.conv1d(t.view(1, 1, -1), s.view(1, 1, -1)).view(-1)
    return c


for i in range(10000):
    N = randint(10, 1000)
    w = Variable(torch.zeros([N]))
    torch.nn.init.uniform(w)

    s = Variable(torch.zeros([3]))
    torch.nn.init.uniform(s)


    assert (_convolve_original(w, s) == _convolve_new(w, s)).all()

```