### PR TITLE
Removed the unnecessary softplus in NTMHeadBase._address_memory

### DIFF
--- a/ntm/head.py
+++ b/ntm/head.py
@@ -45,7 +45,7 @@ class NTMHeadBase(nn.Module):
         k = k.clone()
         β = F.softplus(β)
         g = F.sigmoid(g)
-        s = F.softmax(F.softplus(s), dim=1)
+        s = F.softmax(s, dim=1)
         γ = 1 + F.softplus(γ)
 
         w = self.memory.address(k, β, g, s, γ, w_prev)


### PR DESCRIPTION
Removed the softplus in the softmax:
```python
        s = F.softmax(F.softplus(s), dim=1)
```
softmax already constrains the values to (0, 1), the softplus doesn't achieve anything. Pytorch's softmax implementation is already numerically stable, so that's not the preoccupation.