### PR TITLE
Various PyTorch 0.4.0 updates

### DIFF
--- a/ntm/aio.py
+++ b/ntm/aio.py
@@ -1,8 +1,6 @@
 """All in one NTM. Encapsulation of all components."""
 import torch
 from torch import nn
-from torch.autograd import Variable
-
 from .ntm import NTM
 from .controller import LSTMController
 from .head import NTMReadHead, NTMWriteHead
@@ -55,7 +53,7 @@ class EncapsulatedNTM(nn.Module):
 
     def forward(self, x=None):
         if x is None:
-            x = Variable(torch.zeros(self.batch_size, self.num_inputs))
+            x = torch.zeros(self.batch_size, self.num_inputs)
 
         o, self.previous_state = self.ntm(x, self.previous_state)
         return o, self.previous_state

--- a/ntm/controller.py
+++ b/ntm/controller.py
@@ -33,10 +33,10 @@ class LSTMController(nn.Module):
     def reset_parameters(self):
         for p in self.lstm.parameters():
             if p.dim() == 1:
-                nn.init.constant(p, 0)
+                nn.init.constant_(p, 0)
             else:
                 stdev = 5 / (np.sqrt(self.num_inputs +  self.num_outputs))
-                nn.init.uniform(p, -stdev, stdev)
+                nn.init.uniform_(p, -stdev, stdev)
 
     def size(self):
         return self.num_inputs, self.num_outputs

--- a/ntm/head.py
+++ b/ntm/head.py
@@ -1,7 +1,6 @@
 """NTM Read and Write Heads."""
 import torch
 from torch import nn
-from torch.autograd import Variable
 import torch.nn.functional as F
 import numpy as np
 
@@ -64,12 +63,12 @@ class NTMReadHead(NTMHeadBase):
 
     def create_new_state(self, batch_size):
         # The state holds the previous time step address weightings
-        return Variable(torch.zeros(batch_size, self.N))
+        return torch.zeros(batch_size, self.N)
 
     def reset_parameters(self):
         # Initialize the linear layers
-        nn.init.xavier_uniform(self.fc_read.weight, gain=1.4)
-        nn.init.normal(self.fc_read.bias, std=0.01)
+        nn.init.xavier_uniform_(self.fc_read.weight, gain=1.4)
+        nn.init.normal_(self.fc_read.bias, std=0.01)
 
     def is_read_head(self):
         return True
@@ -100,12 +99,12 @@ class NTMWriteHead(NTMHeadBase):
         self.reset_parameters()
 
     def create_new_state(self, batch_size):
-        return Variable(torch.zeros(batch_size, self.N))
+        return torch.zeros(batch_size, self.N)
 
     def reset_parameters(self):
         # Initialize the linear layers
-        nn.init.xavier_uniform(self.fc_write.weight, gain=1.4)
-        nn.init.normal(self.fc_write.bias, std=0.01)
+        nn.init.xavier_uniform_(self.fc_write.weight, gain=1.4)
+        nn.init.normal_(self.fc_write.bias, std=0.01)
 
     def is_read_head(self):
         return False

--- a/ntm/memory.py
+++ b/ntm/memory.py
@@ -1,6 +1,5 @@
 """An NTM's memory implementation."""
 import torch
-from torch.autograd import Variable
 import torch.nn.functional as F
 from torch import nn
 import numpy as np
@@ -32,11 +31,11 @@ class NTMMemory(nn.Module):
 
         # The memory bias allows the heads to learn how to initially address
         # memory locations by content
-        self.register_buffer('mem_bias', Variable(torch.Tensor(N, M)))
+        self.register_buffer('mem_bias', torch.Tensor(N, M))
 
         # Initialize memory bias
         stdev = 1 / (np.sqrt(N + M))
-        nn.init.uniform(self.mem_bias, -stdev, stdev)
+        nn.init.uniform_(self.mem_bias, -stdev, stdev)
 
     def reset(self, batch_size):
         """Initialize memory from bias, for start-of-sequence."""
@@ -53,7 +52,7 @@ class NTMMemory(nn.Module):
     def write(self, w, e, a):
         """write to memory (according to section 3.2)."""
         self.prev_mem = self.memory
-        self.memory = Variable(torch.Tensor(self.batch_size, self.N, self.M))
+        self.memory = torch.Tensor(self.batch_size, self.N, self.M)
         erase = torch.matmul(w.unsqueeze(-1), e.unsqueeze(1))
         add = torch.matmul(w.unsqueeze(-1), a.unsqueeze(1))
         self.memory = self.prev_mem * (1 - erase) + add
@@ -89,7 +88,7 @@ class NTMMemory(nn.Module):
         return g * wc + (1 - g) * w_prev
 
     def _shift(self, wg, s):
-        result = Variable(torch.zeros(wg.size()))
+        result = torch.zeros(wg.size())
         for b in range(self.batch_size):
             result[b] = _convolve(wg[b], s[b])
         return result

--- a/ntm/ntm.py
+++ b/ntm/ntm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import torch
 from torch import nn
-from torch.autograd import Variable
 import torch.nn.functional as F
 
 
@@ -37,7 +36,7 @@ class NTM(nn.Module):
         self.init_r = []
         for head in heads:
             if head.is_read_head():
-                init_r_bias = Variable(torch.randn(1, self.M) * 0.01)
+                init_r_bias = torch.randn(1, self.M) * 0.01
                 self.register_buffer("read{}_bias".format(self.num_read_heads), init_r_bias.data)
                 self.init_r += [init_r_bias]
                 self.num_read_heads += 1
@@ -58,8 +57,8 @@ class NTM(nn.Module):
 
     def reset_parameters(self):
         # Initialize the linear layer
-        nn.init.xavier_uniform(self.fc.weight, gain=1)
-        nn.init.normal(self.fc.bias, std=0.01)
+        nn.init.xavier_uniform_(self.fc.weight, gain=1)
+        nn.init.normal_(self.fc.bias, std=0.01)
 
     def forward(self, x, prev_state):
         """NTM forward function.

--- a/tasks/copytask.py
+++ b/tasks/copytask.py
@@ -4,7 +4,6 @@ import random
 from attr import attrs, attrib, Factory
 import torch
 from torch import nn
-from torch.autograd import Variable
 from torch import optim
 import numpy as np
 
@@ -38,10 +37,10 @@ def dataloader(num_batches,
         # All batches have the same sequence length
         seq_len = random.randint(min_len, max_len)
         seq = np.random.binomial(1, 0.5, (seq_len, batch_size, seq_width))
-        seq = Variable(torch.from_numpy(seq))
+        seq = torch.from_numpy(seq)
 
         # The input includes an additional channel used for the delimiter
-        inp = Variable(torch.zeros(seq_len + 1, batch_size, seq_width + 1))
+        inp = torch.zeros(seq_len + 1, batch_size, seq_width + 1)
         inp[:seq_len, :, :seq_width] = seq
         inp[seq_len, :, seq_width] = 1.0 # delimiter in our control channel
         outp = seq.clone()

--- a/tasks/repeatcopytask.py
+++ b/tasks/repeatcopytask.py
@@ -4,7 +4,6 @@ import random
 from attr import attrs, attrib, Factory
 import torch
 from torch import nn
-from torch.autograd import Variable
 from torch import optim
 import numpy as np
 
@@ -55,16 +54,16 @@ def dataloader(num_batches,
 
         # Generate the sequence
         seq = np.random.binomial(1, 0.5, (seq_len, batch_size, seq_width))
-        seq = Variable(torch.from_numpy(seq))
+        seq = torch.from_numpy(seq)
 
         # The input includes 2 additional channels, for end-of-sequence and num-reps
-        inp = Variable(torch.zeros(seq_len + 2, batch_size, seq_width + 2))
+        inp = torch.zeros(seq_len + 2, batch_size, seq_width + 2)
         inp[:seq_len, :, :seq_width] = seq
         inp[seq_len, :, seq_width] = 1.0
         inp[seq_len+1, :, seq_width+1] = rpt_normalize(reps)
 
         # The output contain the repeated sequence + end marker
-        outp = Variable(torch.zeros(seq_len * reps + 1, batch_size, seq_width + 1))
+        outp = torch.zeros(seq_len * reps + 1, batch_size, seq_width + 1)
         outp[:seq_len * reps, :, :seq_width] = seq.clone().repeat(reps, 1, 1)
         outp[seq_len * reps, :, seq_width] = 1.0 # End marker
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,10 +1,9 @@
 import pytest
 import torch
-from torch.autograd import Variable
 from ntm.memory import NTMMemory
 
 def _t(*l):
-    return Variable(torch.Tensor(l)).unsqueeze(0)
+    return torch.Tensor(l).unsqueeze(0)
 
 class TestMemoryReadWrite:
     N = 4

--- a/train.py
+++ b/train.py
@@ -13,7 +13,6 @@ import sys
 import attr
 import argcomplete
 import torch
-from torch.autograd import Variable
 import numpy as np
 
 
@@ -104,7 +103,7 @@ def train_batch(net, criterion, optimizer, X, Y):
         net(X[i])
 
     # Read the output (no input given)
-    y_out = Variable(torch.zeros(Y.size()))
+    y_out = torch.zeros(Y.size())
     for i in range(outp_seq_len):
         y_out[i], _ = net()
 
@@ -119,7 +118,7 @@ def train_batch(net, criterion, optimizer, X, Y):
     # The cost is the number of error bits per sequence
     cost = torch.sum(torch.abs(y_out_binarized - Y.data))
 
-    return loss.data[0], cost / batch_size
+    return loss.item(), cost / batch_size
 
 
 def evaluate(net, criterion, X, Y):
@@ -137,7 +136,7 @@ def evaluate(net, criterion, X, Y):
         states += [state]
 
     # Read the output (no input given)
-    y_out = Variable(torch.zeros(Y.size()))
+    y_out = torch.zeros(Y.size())
     for i in range(outp_seq_len):
         y_out[i], state = net()
         states += [state]


### PR DESCRIPTION
This commit fixes a few deprecation warnings thrown by PyTorch 0.4.0.

Merge of Variable and Tensor:
- change `Variable(a_tensor)` to `a_tensor`

Support for PyTorch Scalars of 0-dimension
- change`loss.data[0]` to `loss.item()`

Naming conventions in nn.init
- change `nn.init.constant` to `nn.init.constant_`
- change `nn.init.uniform` to `nn.init.uniform_`
- change `nn.init.xavier_uniform` to `nn.init.xavier_uniform_`

This pull request does not fix `TypeError: Object of type 'Tensor' is not JSON serializable` thrown by `save_checkpoint` on line 83 of train.py, which seems to be an issue new to PyTorch 0.4.0.

Thanks! This is a great implementation!!!
Mark
